### PR TITLE
ci: fix github-script usage in workflows

### DIFF
--- a/.github/workflows/pr-check-command.yml
+++ b/.github/workflows/pr-check-command.yml
@@ -97,7 +97,7 @@ jobs:
                 },
               });
 
-              core.setFailed('PR must reference an issue');
+              throw new Error('PR must reference an issue');
               return;
             }
 
@@ -177,7 +177,7 @@ jobs:
                 },
               });
 
-              core.setFailed('PR author must be assigned to the linked issue');
+              throw new Error('PR author must be assigned to the linked issue');
             } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-requirements.yml
+++ b/.github/workflows/pr-requirements.yml
@@ -72,7 +72,7 @@ jobs:
                 state: 'closed',
               });
 
-              core.setFailed('PR must reference an issue');
+              throw new Error('PR must reference an issue');
               return;
             }
 
@@ -151,7 +151,7 @@ jobs:
                 state: 'closed',
               });
 
-              core.setFailed('PR author must be assigned to the linked issue');
+              throw new Error('PR author must be assigned to the linked issue');
             } else {
               console.log(`PR requirements met! Issue #${issueWithAuthorAssigned} has ${prAuthor} as assignee.`);
             }


### PR DESCRIPTION
Replaced core.setFailed(...) with thrown Errors inside actions/github-script blocks to avoid ReferenceError when 'core' isn't available.